### PR TITLE
Use unique ID for workers

### DIFF
--- a/lib/together/supervisor.ex
+++ b/lib/together/supervisor.ex
@@ -73,11 +73,11 @@ defmodule Together.Supervisor do
     worker_name = {:via, Registry, {@registry_name, name}}
 
     [
-      worker(Proxy, [worker_name, [name: proxy_name]]),
+      worker(Proxy, [worker_name, [name: proxy_name]], [id: make_ref()]),
       worker(Worker, [
         [store: store_name, proxy: proxy_name] ++ worker_spec,
         [name: worker_name]
-      ])
+      ], [id: make_ref()])
     ]
   end
 end


### PR DESCRIPTION
I found that it wasn't possible to have multiple workers defined as per the docs, IE:

```elixir
config :together,
  workers: [
    [name: "throttled", delay: 5_000, type: :throttle],
    [name: "debounced", delay: 5_000, type: :debounce]
  ]
```

This errors out with:

```
** (Mix) Could not start application test_app: TestApp.start(:normal, []) returned an error: shutdown: failed to start child: Together.Supervisor
    ** (EXIT) an exception was raised:
        ** (ArgumentError) duplicated id Together.Proxy found in the supervisor specification, please explicitly pass the :id option when defining this worker/supervisor
            (elixir) lib/supervisor/spec.ex:175: Supervisor.Spec.assert_unique_ids/1
            (elixir) lib/supervisor/spec.ex:169: Supervisor.Spec.supervise/2
            (stdlib) supervisor.erl:294: :supervisor.init/1
            (stdlib) gen_server.erl:328: :gen_server.init_it/6
            (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
```

This change uses Kernel.make_ref() to make a unique ID for each worker so that multiple workers can be defined in an application.

Not sure how to test this properly, any advice there would be very welcome if you'd prefer a PR with a test!

Thanks.
