### PR TITLE
Update documentation re. shards

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ def deps do
 end
 ```
 
+Since ex_shards uses shards, make sure that shards is started before your application:
+
+```elixir
+def application do
+  [applications: [:shards]]
+end
+```
+
 ## How to use
 
 Start `Together.Supervisor` to use it


### PR DESCRIPTION
As per Ex-shards documentation, "since ex_shards uses shards, make sure that shards is started before your application"

Failure to do so results in this error:

```elixir
** (Mix) Could not start application MyApp: MyApp.start(:normal, []) returned an error: shutdown: failed to start child: Together.Supervisor
    ** (EXIT) shutdown: failed to start child: Together.Store
        ** (EXIT) an exception was raised:
            ** (CaseClauseError) no case clause matching: {:error, {:noproc, {:gen_server, :call, [:shards_sup, {:start_child, [MyApp.Together.Store.Shards, []]}, :infinity]}}}
                lib/together/store.ex:3: Together.Store.start_link/2
                (stdlib) supervisor.erl:365: :supervisor.do_start_child/2
                (stdlib) supervisor.erl:348: :supervisor.start_children/3
                (stdlib) supervisor.erl:314: :supervisor.init_children/2
                (stdlib) gen_server.erl:365: :gen_server.init_it/2
                (stdlib) gen_server.erl:333: :gen_server.init_it/6
                (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
```